### PR TITLE
Fix handling "/seedcracker" command (#187)

### DIFF
--- a/src/main/java/kaptainwutax/seedcrackerX/command/ClientCommand.java
+++ b/src/main/java/kaptainwutax/seedcrackerX/command/ClientCommand.java
@@ -4,6 +4,7 @@ import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import kaptainwutax.seedcrackerX.init.ClientCommands;
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import kaptainwutax.seedcrackerX.util.Log;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
@@ -27,7 +28,11 @@ public abstract class ClientCommand {
     public final void register(CommandDispatcher<FabricClientCommandSource> dispatcher) {
         LiteralArgumentBuilder<FabricClientCommandSource> builder = literal(this.getName());
         this.build(builder);
-        dispatcher.register(literal(ClientCommands.PREFIX).then(builder));
+        LiteralArgumentBuilder<FabricClientCommandSource> seedCrackerRootCommand = literal(ClientCommands.PREFIX)
+        .executes(context -> {
+            Log.error("Error: please enter a valid seedcracker command");
+            return 1;
+        });
+        dispatcher.register(seedCrackerRootCommand.then(builder));
     }
-
 }


### PR DESCRIPTION
This change solves the issue #187, displaying an error message instead of sending the command to the server.