### PR TITLE
Replace stdout with SLF4J LoggerFactory for improved logging (#137)

### DIFF
--- a/src/main/java/kaptainwutax/seedcrackerX/config/Config.java
+++ b/src/main/java/kaptainwutax/seedcrackerX/config/Config.java
@@ -7,9 +7,14 @@ import com.seedfinding.mccore.version.MCVersion;
 import kaptainwutax.seedcrackerX.Features;
 import kaptainwutax.seedcrackerX.util.FeatureToggle;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.*;
 
 public class Config {
+    public static Logger logger = LoggerFactory.getLogger("config");
+
     private static final File file = new File(net.fabricmc.loader.api.FabricLoader.getInstance().getConfigDir().toFile(), "seedcracker.json");
     private static Config INSTANCE = new Config();
     public FeatureToggle buriedTreasure = new FeatureToggle(true);
@@ -43,7 +48,7 @@ public class Config {
 
             gson.toJson(INSTANCE, writer);
         } catch (IOException e) {
-            System.out.println("seedcracker could't save config");
+            logger.error("seedcracker could't save config");
             e.printStackTrace();
         }
     }
@@ -55,10 +60,10 @@ public class Config {
             INSTANCE = gson.fromJson(reader, Config.class);
         } catch (Exception e) {
             if (file.exists()) {
-                System.out.println("seedcracker couldn't load config, deleting it...");
+                logger.error("seedcracker couldn't load config, deleting it...");
                 file.delete();
             } else {
-                System.out.println("seedcracker couldn't find config");
+                logger.warn("seedcracker couldn't find config");
             }
         }
     }

--- a/src/main/java/kaptainwutax/seedcrackerX/config/Config.java
+++ b/src/main/java/kaptainwutax/seedcrackerX/config/Config.java
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
 import java.io.*;
 
 public class Config {
-    public static Logger logger = LoggerFactory.getLogger("config");
+    private static final Logger logger = LoggerFactory.getLogger("config");
 
     private static final File file = new File(net.fabricmc.loader.api.FabricLoader.getInstance().getConfigDir().toFile(), "seedcracker.json");
     private static Config INSTANCE = new Config();

--- a/src/main/java/kaptainwutax/seedcrackerX/config/Config.java
+++ b/src/main/java/kaptainwutax/seedcrackerX/config/Config.java
@@ -48,8 +48,7 @@ public class Config {
 
             gson.toJson(INSTANCE, writer);
         } catch (IOException e) {
-            logger.error("seedcracker could't save config");
-            e.printStackTrace();
+            logger.error("seedcracker could't save config", e);
         }
     }
 
@@ -60,10 +59,10 @@ public class Config {
             INSTANCE = gson.fromJson(reader, Config.class);
         } catch (Exception e) {
             if (file.exists()) {
-                logger.error("seedcracker couldn't load config, deleting it...");
+                logger.error("seedcracker couldn't load config, deleting it...", e);
                 file.delete();
             } else {
-                logger.warn("seedcracker couldn't find config");
+                logger.warn("seedcracker couldn't find config", e);
             }
         }
     }

--- a/src/main/java/kaptainwutax/seedcrackerX/config/StructureSave.java
+++ b/src/main/java/kaptainwutax/seedcrackerX/config/StructureSave.java
@@ -16,7 +16,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class StructureSave {
+    public static Logger logger = LoggerFactory.getLogger("structureSave");
 
     public static final File saveDir = new File(FabricLoader.getInstance().getConfigDir().toFile(), "SeedCrackerX saved structures");
     private static final List<RegionStructure<?,?>> structureTypes = List.of(Features.IGLOO,Features.BURIED_TREASURE,
@@ -39,6 +43,7 @@ public class StructureSave {
             }
             writer.close();
         } catch (IOException e) {
+            logger.error("seedcracker could't save structures");
             e.printStackTrace();
         }
     }
@@ -64,6 +69,7 @@ public class StructureSave {
                 }
             }
         } catch (IOException e) {
+            logger.error("seedcracker could't load previous structures");
             e.printStackTrace();
         }
         return result;

--- a/src/main/java/kaptainwutax/seedcrackerX/config/StructureSave.java
+++ b/src/main/java/kaptainwutax/seedcrackerX/config/StructureSave.java
@@ -20,7 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class StructureSave {
-    public static Logger logger = LoggerFactory.getLogger("structureSave");
+    private static final Logger logger = LoggerFactory.getLogger("structureSave");
 
     public static final File saveDir = new File(FabricLoader.getInstance().getConfigDir().toFile(), "SeedCrackerX saved structures");
     private static final List<RegionStructure<?,?>> structureTypes = List.of(Features.IGLOO,Features.BURIED_TREASURE,

--- a/src/main/java/kaptainwutax/seedcrackerX/config/StructureSave.java
+++ b/src/main/java/kaptainwutax/seedcrackerX/config/StructureSave.java
@@ -43,8 +43,7 @@ public class StructureSave {
             }
             writer.close();
         } catch (IOException e) {
-            logger.error("seedcracker could't save structures");
-            e.printStackTrace();
+            logger.error("seedcracker could't save structures", e);
         }
     }
 
@@ -69,8 +68,7 @@ public class StructureSave {
                 }
             }
         } catch (IOException e) {
-            logger.error("seedcracker could't load previous structures");
-            e.printStackTrace();
+            logger.error("seedcracker could't load previous structures", e);
         }
         return result;
     }

--- a/src/main/java/kaptainwutax/seedcrackerX/cracker/storage/TimeMachine.java
+++ b/src/main/java/kaptainwutax/seedcrackerX/cracker/storage/TimeMachine.java
@@ -34,7 +34,11 @@ import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class TimeMachine {
+    public static Logger logger = LoggerFactory.getLogger("timeMachine");
 
     public static ExecutorService SERVICE = Executors.newFixedThreadPool(5);
 
@@ -291,7 +295,7 @@ public class TimeMachine {
                                 Log.warn("tmachine.printSeedsInConsole");
                             }
                         } else {
-                            System.out.println("Found world seed " + worldSeed);
+                            logger.info("Found world seed " + worldSeed);
                         }
                     }
 
@@ -389,7 +393,7 @@ public class TimeMachine {
                             Log.warn("tmachine.printSeedsInConsole");
                         }
                     } else {
-                        System.out.println("Found world seed " + worldSeed);
+                        logger.info("Found world seed " + worldSeed);
                     }
                 }
 

--- a/src/main/java/kaptainwutax/seedcrackerX/cracker/storage/TimeMachine.java
+++ b/src/main/java/kaptainwutax/seedcrackerX/cracker/storage/TimeMachine.java
@@ -38,7 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class TimeMachine {
-    public static Logger logger = LoggerFactory.getLogger("timeMachine");
+    private static final Logger logger = LoggerFactory.getLogger("timeMachine");
 
     public static ExecutorService SERVICE = Executors.newFixedThreadPool(5);
 

--- a/src/main/java/kaptainwutax/seedcrackerX/finder/decorator/WarpedFungusFinder.java
+++ b/src/main/java/kaptainwutax/seedcrackerX/finder/decorator/WarpedFungusFinder.java
@@ -25,7 +25,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class WarpedFungusFinder extends BlockFinder {
+    public static Logger logger = LoggerFactory.getLogger("warpedFungusFinder");
 
     private static final Predicate<Block> prdc = block -> (block == Blocks.SHROOMLIGHT || block == Blocks.WARPED_WART_BLOCK);
 
@@ -204,7 +208,7 @@ public class WarpedFungusFinder extends BlockFinder {
                             blocktype = 3;
                         } else {
                             blocktype = 0;
-                            System.out.println("error found illegal Block: " + block.getName() + " at " + pos.add(x, y, z).toShortString());
+                            logger.error("error found illegal Block: " + block.getName() + " at " + pos.add(x, y, z).toShortString());
                         }
                         layers[counter][x + layerSize][z + layerSize] = blocktype;
                     }

--- a/src/main/java/kaptainwutax/seedcrackerX/finder/decorator/WarpedFungusFinder.java
+++ b/src/main/java/kaptainwutax/seedcrackerX/finder/decorator/WarpedFungusFinder.java
@@ -29,7 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class WarpedFungusFinder extends BlockFinder {
-    public static Logger logger = LoggerFactory.getLogger("warpedFungusFinder");
+    private static final Logger logger = LoggerFactory.getLogger("warpedFungusFinder");
 
     private static final Predicate<Block> prdc = block -> (block == Blocks.SHROOMLIGHT || block == Blocks.WARPED_WART_BLOCK);
 


### PR DESCRIPTION
This change addresses the issue #137. It replaces the direct usage of stdout with LoggerFactory from the SLF4J framework for improved logging. In the future, it would be useful to implement a better logging system.