### PR TITLE
Optimising save and load structures functionality

### DIFF
--- a/src/main/java/kaptainwutax/seedcrackerX/config/StructureSave.java
+++ b/src/main/java/kaptainwutax/seedcrackerX/config/StructureSave.java
@@ -73,13 +73,14 @@ public class StructureSave {
     }
 
     private static String getWorldName() {
-        if (MinecraftClient.getInstance().getNetworkHandler() != null) {
-            ClientConnection connection = MinecraftClient.getInstance().getNetworkHandler().getConnection();
+        MinecraftClient minecraftClient = MinecraftClient.getInstance();
+        if (minecraftClient.getNetworkHandler() != null) {
+            ClientConnection connection = minecraftClient.getNetworkHandler().getConnection();
             if (connection.isLocal()) {
-                String address = MinecraftClient.getInstance().getServer().getSavePath(WorldSavePath.ROOT).getParent().getFileName().toString();
+                String address = minecraftClient.getServer().getSavePath(WorldSavePath.ROOT).getParent().getFileName().toString();
                 return address.replace("/","_").replace(":", "_")+".txt";
             } else {
-                return connection.getAddress().toString().replace("/","_").replace(":", "_")+".txt";
+                return connection.getAddress().toString().replace("/","_").replace(":","_")+".txt";
             }
         }
         return "Invalid.txt";

--- a/src/main/java/kaptainwutax/seedcrackerX/config/StructureSave.java
+++ b/src/main/java/kaptainwutax/seedcrackerX/config/StructureSave.java
@@ -32,16 +32,16 @@ public class StructureSave {
         File saveFile = new File(saveDir, getWorldName());
         try {
             saveFile.createNewFile();
-            FileWriter writer = new FileWriter(saveFile);
-            for (DataStorage.Entry<Feature.Data<?>> dataEntry : baseData) {
-                if (dataEntry.data.feature instanceof Structure structure) {
-                    String data = Structure.getName(structure.getClass()) + ";" + dataEntry.data.chunkX +
+            try (FileWriter writer = new FileWriter(saveFile)) {
+                for (DataStorage.Entry<Feature.Data<?>> dataEntry : baseData) {
+                    if (dataEntry.data.feature instanceof Structure structure) {
+                        String data = Structure.getName(structure.getClass()) + ";" + dataEntry.data.chunkX +
                             ";" + dataEntry.data.chunkZ +
                             "\n";
-                    writer.write(data);
+                        writer.write(data);
+                    }
                 }
             }
-            writer.close();
         } catch (IOException e) {
             logger.error("seedcracker couldn't save structures", e);
         }
@@ -52,9 +52,8 @@ public class StructureSave {
         File saveFile = new File(saveDir, getWorldName());
         List<RegionStructure.Data<?>> result = new ArrayList<>();
         if (!saveFile.exists()) return result;
-        try {
-            FileInputStream fis = new FileInputStream(saveFile);
-            Scanner sc = new Scanner(fis);
+        try (FileInputStream fis = new FileInputStream(saveFile);
+            Scanner sc = new Scanner(fis)) {
             while (sc.hasNextLine()) {
                 String line = sc.nextLine();
                 String[] info = line.split(";");

--- a/src/main/java/kaptainwutax/seedcrackerX/config/StructureSave.java
+++ b/src/main/java/kaptainwutax/seedcrackerX/config/StructureSave.java
@@ -52,8 +52,10 @@ public class StructureSave {
         File saveFile = new File(saveDir, getWorldName());
         List<RegionStructure.Data<?>> result = new ArrayList<>();
         if (!saveFile.exists()) return result;
-        try (FileInputStream fis = new FileInputStream(saveFile);
-            Scanner sc = new Scanner(fis)) {
+        try (
+            FileInputStream fis = new FileInputStream(saveFile);
+            Scanner sc = new Scanner(fis)
+        ) {
             while (sc.hasNextLine()) {
                 String line = sc.nextLine();
                 String[] info = line.split(";");
@@ -66,6 +68,8 @@ public class StructureSave {
                     }
                 }
             }
+        } catch (FileNotFoundException e) {
+            logger.warn("seedcracker couldn't find the structures file", e);
         } catch (IOException e) {
             logger.error("seedcracker couldn't load previous structures", e);
         }

--- a/src/main/java/kaptainwutax/seedcrackerX/config/StructureSave.java
+++ b/src/main/java/kaptainwutax/seedcrackerX/config/StructureSave.java
@@ -43,7 +43,7 @@ public class StructureSave {
             }
             writer.close();
         } catch (IOException e) {
-            logger.error("seedcracker could't save structures", e);
+            logger.error("seedcracker couldn't save structures", e);
         }
     }
 
@@ -68,7 +68,7 @@ public class StructureSave {
                 }
             }
         } catch (IOException e) {
-            logger.error("seedcracker could't load previous structures", e);
+            logger.error("seedcracker couldn't load previous structures", e);
         }
         return result;
     }
@@ -78,9 +78,9 @@ public class StructureSave {
             ClientConnection connection = MinecraftClient.getInstance().getNetworkHandler().getConnection();
             if (connection.isLocal()) {
                 String address = MinecraftClient.getInstance().getServer().getSavePath(WorldSavePath.ROOT).getParent().getFileName().toString();
-                return address.replace("/","_")+".txt";
+                return address.replace("/","_").replace(":", "_")+".txt";
             } else {
-                return connection.getAddress().toString().replace("/","_")+".txt";
+                return connection.getAddress().toString().replace("/","_").replace(":", "_")+".txt";
             }
         }
         return "Invalid.txt";

--- a/src/main/java/kaptainwutax/seedcrackerX/config/StructureSave.java
+++ b/src/main/java/kaptainwutax/seedcrackerX/config/StructureSave.java
@@ -12,6 +12,9 @@ import net.minecraft.network.ClientConnection;
 import net.minecraft.util.WorldSavePath;
 
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
@@ -22,20 +25,22 @@ import org.slf4j.LoggerFactory;
 public class StructureSave {
     private static final Logger logger = LoggerFactory.getLogger("structureSave");
 
-    public static final File saveDir = new File(FabricLoader.getInstance().getConfigDir().toFile(), "SeedCrackerX saved structures");
+    public static final Path saveDir = Paths.get(FabricLoader.getInstance().getConfigDir().toFile().toString(), "SeedCrackerX saved structures");
     private static final List<RegionStructure<?,?>> structureTypes = List.of(Features.IGLOO,Features.BURIED_TREASURE,
             Features.PILLAGER_OUTPOST,Features.DESERT_PYRAMID, Features.JUNGLE_PYRAMID, Features.END_CITY,
             Features.MONUMENT, Features.SHIPWRECK, Features.SWAMP_HUT);
 
     public static void saveStructures(ScheduledSet<DataStorage.Entry<Feature.Data<?>>> baseData) {
-        saveDir.mkdirs();
-        File saveFile = new File(saveDir, getWorldName());
         try {
-            saveFile.createNewFile();
-            try (FileWriter writer = new FileWriter(saveFile)) {
+            Files.createDirectories(saveDir);
+            Path saveFile = saveDir.resolve(getWorldName());
+            Files.deleteIfExists(saveFile);
+            Files.createFile(saveFile);
+            try (FileWriter writer = new FileWriter(saveFile.toFile())) {
                 for (DataStorage.Entry<Feature.Data<?>> dataEntry : baseData) {
                     if (dataEntry.data.feature instanceof Structure structure) {
-                        String data = Structure.getName(structure.getClass()) + ";" + dataEntry.data.chunkX +
+                        String data = Structure.getName(structure.getClass()) +
+                            ";" + dataEntry.data.chunkX +
                             ";" + dataEntry.data.chunkZ +
                             "\n";
                         writer.write(data);
@@ -48,28 +53,30 @@ public class StructureSave {
     }
 
     public static List<RegionStructure.Data<?>> loadStructures() {
-        saveDir.mkdirs();
-        File saveFile = new File(saveDir, getWorldName());
         List<RegionStructure.Data<?>> result = new ArrayList<>();
-        if (!saveFile.exists()) return result;
-        try (
-            FileInputStream fis = new FileInputStream(saveFile);
-            Scanner sc = new Scanner(fis)
-        ) {
-            while (sc.hasNextLine()) {
-                String line = sc.nextLine();
-                String[] info = line.split(";");
-                if (info.length != 3) continue;
-                String structureName = info[0];
-                for (RegionStructure<?,?> idk : structureTypes) {
-                    if (structureName.equals(idk.getName())) {
-                        result.add(idk.at(Integer.parseInt(info[1]), Integer.parseInt(info[2])));
-                        break;
+        try {
+            Files.createDirectories(saveDir);
+            Path saveFile = saveDir.resolve(getWorldName());
+            try (
+                FileInputStream fis = new FileInputStream(saveFile.toFile());
+                Scanner sc = new Scanner(fis)
+            ) {
+                while (sc.hasNextLine()) {
+                    String line = sc.nextLine();
+                    String[] info = line.split(";");
+                    if (info.length != 3) continue;
+                    String structureName = info[0];
+                    for (RegionStructure<?,?> idk : structureTypes) {
+                        if (structureName.equals(idk.getName())) {
+                            result.add(idk.at(Integer.parseInt(info[1]), Integer.parseInt(info[2])));
+                            break;
+                        }
                     }
                 }
             }
         } catch (FileNotFoundException e) {
             logger.warn("seedcracker couldn't find the structures file", e);
+            return result;
         } catch (IOException e) {
             logger.error("seedcracker couldn't load previous structures", e);
         }


### PR DESCRIPTION
These changes improve the saving and loading structures operations by using the Path class instead of the File class and making other minor improvements. This also fixes the issue #84 , which prevented saving the structures file for servers on Windows due to the “:” character in filename ([reserved](https://en.wikipedia.org/wiki/Filename#Comparison_of_filename_limitations)). Now the “_” character is used instead of “:”.