### PR TITLE
Remove usage of deprecated ConcurrentSet class

### DIFF
--- a/src/main/java/kaptainwutax/seedcrackerX/cracker/storage/DataStorage.java
+++ b/src/main/java/kaptainwutax/seedcrackerX/cracker/storage/DataStorage.java
@@ -5,7 +5,6 @@ import com.seedfinding.mcfeature.Feature;
 import com.seedfinding.mcfeature.decorator.DesertWell;
 import com.seedfinding.mcfeature.decorator.EndGateway;
 import com.seedfinding.mcfeature.structure.*;
-import io.netty.util.internal.ConcurrentSet;
 import kaptainwutax.seedcrackerX.config.ConfigScreen;
 import kaptainwutax.seedcrackerX.cracker.BiomeData;
 import kaptainwutax.seedcrackerX.cracker.DataAddedEvent;


### PR DESCRIPTION
This pull request removes the usage of the [deprecated](https://netty.io/4.1/api/io/netty/util/internal/ConcurrentSet.html) ConcurrentSet class in the Netty library.