### PR TITLE
better error reporting on initialization exceptions

### DIFF
--- a/src/main/java/kaptainwutax/seedcrackerX/Features.java
+++ b/src/main/java/kaptainwutax/seedcrackerX/Features.java
@@ -1,6 +1,7 @@
 package kaptainwutax.seedcrackerX;
 
 import com.seedfinding.mccore.version.MCVersion;
+import com.seedfinding.mcfeature.Feature;
 import com.seedfinding.mcfeature.decorator.DesertWell;
 import com.seedfinding.mcfeature.decorator.EndGateway;
 import com.seedfinding.mcfeature.structure.*;
@@ -9,7 +10,12 @@ import kaptainwutax.seedcrackerX.cracker.decorator.Dungeon;
 import kaptainwutax.seedcrackerX.cracker.decorator.EmeraldOre;
 import kaptainwutax.seedcrackerX.cracker.decorator.WarpedFungus;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
 public class Features {
+    public static final List<RegionStructure<?, ?>> STRUCTURE_TYPES = new ArrayList<>();
 
     public static BuriedTreasure BURIED_TREASURE;
     public static DesertPyramid DESERT_PYRAMID;
@@ -29,15 +35,15 @@ public class Features {
     public static WarpedFungus WARPED_FUNGUS;
 
     public static void init(MCVersion version) {
-        safe(() -> BURIED_TREASURE = new BuriedTreasure(version));
-        safe(() -> DESERT_PYRAMID = new DesertPyramid(version));
-        safe(() -> END_CITY = new EndCity(version));
-        safe(() -> JUNGLE_PYRAMID = new JunglePyramid(version));
-        safe(() -> MONUMENT = new Monument(version));
-        safe(() -> SHIPWRECK = new Shipwreck(version));
-        safe(() -> SWAMP_HUT = new SwampHut(version));
-        safe(() -> PILLAGER_OUTPOST = new PillagerOutpost(version));
-        safe(() -> IGLOO = new Igloo(version));
+        safe(STRUCTURE_TYPES, () -> BURIED_TREASURE = new BuriedTreasure(version));
+        safe(STRUCTURE_TYPES, () -> DESERT_PYRAMID = new DesertPyramid(version));
+        safe(STRUCTURE_TYPES, () -> END_CITY = new EndCity(version));
+        safe(STRUCTURE_TYPES, () -> JUNGLE_PYRAMID = new JunglePyramid(version));
+        safe(STRUCTURE_TYPES, () -> MONUMENT = new Monument(version));
+        safe(STRUCTURE_TYPES, () -> SHIPWRECK = new Shipwreck(version));
+        safe(STRUCTURE_TYPES, () -> SWAMP_HUT = new SwampHut(version));
+        safe(STRUCTURE_TYPES, () -> PILLAGER_OUTPOST = new PillagerOutpost(version));
+        safe(STRUCTURE_TYPES, () -> IGLOO = new Igloo(version));
 
         safe(() -> END_GATEWAY = new EndGateway(version));
         safe(() -> DESERT_WELL = new DesertWell(version));
@@ -47,11 +53,18 @@ public class Features {
         safe(() -> WARPED_FUNGUS = new WarpedFungus(version));
     }
 
-    private static void safe(Runnable runnable) {
+    private static <F extends Feature<?, ?>> F safe(Supplier<F> lambda) {
         try {
-            runnable.run();
-        } catch (Exception e) {
+            return lambda.get();
+        } catch (Throwable t) {
+            SeedCracker.LOGGER.error("Exception thrown loading feature", t);
+            return null;
         }
+    }
+
+    private static <F extends Feature<?, ?>> void safe(List<F> list, Supplier<F> lambda) {
+        F initializedFeature = safe(lambda);
+        if (initializedFeature != null) list.add(initializedFeature);
     }
 
 }

--- a/src/main/java/kaptainwutax/seedcrackerX/Features.java
+++ b/src/main/java/kaptainwutax/seedcrackerX/Features.java
@@ -37,22 +37,22 @@ public class Features {
     public static void init(MCVersion version) {
         STRUCTURE_TYPES.clear();
 
-        safe(STRUCTURE_TYPES, () -> BURIED_TREASURE = new BuriedTreasure(version));
-        safe(STRUCTURE_TYPES, () -> DESERT_PYRAMID = new DesertPyramid(version));
-        safe(STRUCTURE_TYPES, () -> END_CITY = new EndCity(version));
-        safe(STRUCTURE_TYPES, () -> JUNGLE_PYRAMID = new JunglePyramid(version));
-        safe(STRUCTURE_TYPES, () -> MONUMENT = new Monument(version));
-        safe(STRUCTURE_TYPES, () -> SHIPWRECK = new Shipwreck(version));
-        safe(STRUCTURE_TYPES, () -> SWAMP_HUT = new SwampHut(version));
-        safe(STRUCTURE_TYPES, () -> PILLAGER_OUTPOST = new PillagerOutpost(version));
-        safe(STRUCTURE_TYPES, () -> IGLOO = new Igloo(version));
+        BURIED_TREASURE = safe(STRUCTURE_TYPES, () -> new BuriedTreasure(version));
+        DESERT_PYRAMID = safe(STRUCTURE_TYPES, () -> new DesertPyramid(version));
+        END_CITY = safe(STRUCTURE_TYPES, () -> new EndCity(version));
+        JUNGLE_PYRAMID = safe(STRUCTURE_TYPES, () -> new JunglePyramid(version));
+        MONUMENT = safe(STRUCTURE_TYPES, () -> new Monument(version));
+        SHIPWRECK = safe(STRUCTURE_TYPES, () -> new Shipwreck(version));
+        SWAMP_HUT = safe(STRUCTURE_TYPES, () -> new SwampHut(version));
+        PILLAGER_OUTPOST = safe(STRUCTURE_TYPES, () -> new PillagerOutpost(version));
+        IGLOO = safe(STRUCTURE_TYPES, () -> new Igloo(version));
 
-        safe(() -> END_GATEWAY = new EndGateway(version));
-        safe(() -> DESERT_WELL = new DesertWell(version));
-        safe(() -> EMERALD_ORE = new EmeraldOre(version));
-        safe(() -> DUNGEON = new Dungeon(version));
-        safe(() -> DEEP_DUNGEON = new DeepDungeon(version));
-        safe(() -> WARPED_FUNGUS = new WarpedFungus(version));
+        END_GATEWAY = safe(() -> new EndGateway(version));
+        DESERT_WELL = safe(() -> new DesertWell(version));
+        EMERALD_ORE = safe(() -> new EmeraldOre(version));
+        DUNGEON = safe(() -> new Dungeon(version));
+        DEEP_DUNGEON = safe(() -> new DeepDungeon(version));
+        WARPED_FUNGUS = safe(() -> new WarpedFungus(version));
 
         STRUCTURE_TYPES.trimToSize();
     }
@@ -66,9 +66,10 @@ public class Features {
         }
     }
 
-    private static <F extends Feature<?, ?>> void safe(List<F> list, Supplier<F> lambda) {
+    private static <F extends RegionStructure<?, ?>> F safe(List<RegionStructure<?, ?>> list, Supplier<F> lambda) {
         F initializedFeature = safe(lambda);
         if (initializedFeature != null) list.add(initializedFeature);
+        return initializedFeature;
     }
 
 }

--- a/src/main/java/kaptainwutax/seedcrackerX/Features.java
+++ b/src/main/java/kaptainwutax/seedcrackerX/Features.java
@@ -9,6 +9,7 @@ import kaptainwutax.seedcrackerX.cracker.decorator.DeepDungeon;
 import kaptainwutax.seedcrackerX.cracker.decorator.Dungeon;
 import kaptainwutax.seedcrackerX.cracker.decorator.EmeraldOre;
 import kaptainwutax.seedcrackerX.cracker.decorator.WarpedFungus;
+import kaptainwutax.seedcrackerX.finder.Finder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,37 +38,38 @@ public class Features {
     public static void init(MCVersion version) {
         STRUCTURE_TYPES.clear();
 
-        BURIED_TREASURE = safe(STRUCTURE_TYPES, () -> new BuriedTreasure(version));
-        DESERT_PYRAMID = safe(STRUCTURE_TYPES, () -> new DesertPyramid(version));
-        END_CITY = safe(STRUCTURE_TYPES, () -> new EndCity(version));
-        JUNGLE_PYRAMID = safe(STRUCTURE_TYPES, () -> new JunglePyramid(version));
-        MONUMENT = safe(STRUCTURE_TYPES, () -> new Monument(version));
-        SHIPWRECK = safe(STRUCTURE_TYPES, () -> new Shipwreck(version));
-        SWAMP_HUT = safe(STRUCTURE_TYPES, () -> new SwampHut(version));
-        PILLAGER_OUTPOST = safe(STRUCTURE_TYPES, () -> new PillagerOutpost(version));
-        IGLOO = safe(STRUCTURE_TYPES, () -> new Igloo(version));
+        BURIED_TREASURE = safe(STRUCTURE_TYPES, Finder.Type.BURIED_TREASURE, () -> new BuriedTreasure(version));
+        DESERT_PYRAMID = safe(STRUCTURE_TYPES, Finder.Type.DESERT_TEMPLE, () -> new DesertPyramid(version));
+        END_CITY = safe(STRUCTURE_TYPES, Finder.Type.END_CITY, () -> new EndCity(version));
+        JUNGLE_PYRAMID = safe(STRUCTURE_TYPES, Finder.Type.JUNGLE_TEMPLE, () -> new JunglePyramid(version));
+        MONUMENT = safe(STRUCTURE_TYPES, Finder.Type.MONUMENT, () -> new Monument(version));
+        SHIPWRECK = safe(STRUCTURE_TYPES, Finder.Type.SHIPWRECK, () -> new Shipwreck(version));
+        SWAMP_HUT = safe(STRUCTURE_TYPES, Finder.Type.SWAMP_HUT, () -> new SwampHut(version));
+        PILLAGER_OUTPOST = safe(STRUCTURE_TYPES, Finder.Type.PILLAGER_OUTPOST, () -> new PillagerOutpost(version));
+        IGLOO = safe(STRUCTURE_TYPES, Finder.Type.IGLOO, () -> new Igloo(version));
 
-        END_GATEWAY = safe(() -> new EndGateway(version));
-        DESERT_WELL = safe(() -> new DesertWell(version));
-        EMERALD_ORE = safe(() -> new EmeraldOre(version));
-        DUNGEON = safe(() -> new Dungeon(version));
-        DEEP_DUNGEON = safe(() -> new DeepDungeon(version));
-        WARPED_FUNGUS = safe(() -> new WarpedFungus(version));
+        END_GATEWAY = safe(Finder.Type.END_GATEWAY, () -> new EndGateway(version));
+        DESERT_WELL = safe(Finder.Type.DESERT_WELL, () -> new DesertWell(version));
+        EMERALD_ORE = safe(Finder.Type.EMERALD_ORE, () -> new EmeraldOre(version));
+        DUNGEON = safe(Finder.Type.DUNGEON, () -> new Dungeon(version));
+        DEEP_DUNGEON = safe(Finder.Type.DUNGEON, () -> new DeepDungeon(version));
+        WARPED_FUNGUS = safe(Finder.Type.WARPED_FUNGUS, () -> new WarpedFungus(version));
 
         STRUCTURE_TYPES.trimToSize();
     }
 
-    private static <F extends Feature<?, ?>> F safe(Supplier<F> lambda) {
+    private static <F extends Feature<?, ?>> F safe(Finder.Type finderType, Supplier<F> lambda) {
         try {
             return lambda.get();
         } catch (Throwable t) {
             SeedCracker.LOGGER.error("Exception thrown loading feature", t);
+            finderType.enabled.set(false);
             return null;
         }
     }
 
-    private static <F extends RegionStructure<?, ?>> F safe(List<RegionStructure<?, ?>> list, Supplier<F> lambda) {
-        F initializedFeature = safe(lambda);
+    private static <F extends RegionStructure<?, ?>> F safe(List<RegionStructure<?, ?>> list, Finder.Type finderType, Supplier<F> lambda) {
+        F initializedFeature = safe(finderType, lambda);
         if (initializedFeature != null) list.add(initializedFeature);
         return initializedFeature;
     }

--- a/src/main/java/kaptainwutax/seedcrackerX/Features.java
+++ b/src/main/java/kaptainwutax/seedcrackerX/Features.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.function.Supplier;
 
 public class Features {
-    public static final List<RegionStructure<?, ?>> STRUCTURE_TYPES = new ArrayList<>();
+    public static final ArrayList<RegionStructure<?, ?>> STRUCTURE_TYPES = new ArrayList<>();
 
     public static BuriedTreasure BURIED_TREASURE;
     public static DesertPyramid DESERT_PYRAMID;
@@ -35,6 +35,8 @@ public class Features {
     public static WarpedFungus WARPED_FUNGUS;
 
     public static void init(MCVersion version) {
+        STRUCTURE_TYPES.clear();
+
         safe(STRUCTURE_TYPES, () -> BURIED_TREASURE = new BuriedTreasure(version));
         safe(STRUCTURE_TYPES, () -> DESERT_PYRAMID = new DesertPyramid(version));
         safe(STRUCTURE_TYPES, () -> END_CITY = new EndCity(version));
@@ -51,6 +53,8 @@ public class Features {
         safe(() -> DUNGEON = new Dungeon(version));
         safe(() -> DEEP_DUNGEON = new DeepDungeon(version));
         safe(() -> WARPED_FUNGUS = new WarpedFungus(version));
+
+        STRUCTURE_TYPES.trimToSize();
     }
 
     private static <F extends Feature<?, ?>> F safe(Supplier<F> lambda) {

--- a/src/main/java/kaptainwutax/seedcrackerX/SeedCracker.java
+++ b/src/main/java/kaptainwutax/seedcrackerX/SeedCracker.java
@@ -1,5 +1,6 @@
 package kaptainwutax.seedcrackerX;
 
+import com.mojang.logging.LogUtils;
 import kaptainwutax.seedcrackerX.api.SeedCrackerAPI;
 import kaptainwutax.seedcrackerX.config.Config;
 import kaptainwutax.seedcrackerX.cracker.storage.DataStorage;
@@ -8,11 +9,12 @@ import kaptainwutax.seedcrackerX.init.ClientCommands;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
 import net.fabricmc.loader.api.FabricLoader;
+import org.slf4j.Logger;
 
 import java.util.ArrayList;
 
 public class SeedCracker implements ModInitializer {
-
+    public static final Logger LOGGER = LogUtils.getLogger();
     public static final ArrayList<SeedCrackerAPI> entrypoints = new ArrayList<>();
     private static SeedCracker INSTANCE;
     private final DataStorage dataStorage = new DataStorage();

--- a/src/main/java/kaptainwutax/seedcrackerX/config/StructureSave.java
+++ b/src/main/java/kaptainwutax/seedcrackerX/config/StructureSave.java
@@ -26,9 +26,6 @@ public class StructureSave {
     private static final Logger logger = LoggerFactory.getLogger("structureSave");
 
     public static final Path saveDir = Paths.get(FabricLoader.getInstance().getConfigDir().toFile().toString(), "SeedCrackerX saved structures");
-    private static final List<RegionStructure<?,?>> structureTypes = List.of(Features.IGLOO,Features.BURIED_TREASURE,
-            Features.PILLAGER_OUTPOST,Features.DESERT_PYRAMID, Features.JUNGLE_PYRAMID, Features.END_CITY,
-            Features.MONUMENT, Features.SHIPWRECK, Features.SWAMP_HUT);
 
     public static void saveStructures(ScheduledSet<DataStorage.Entry<Feature.Data<?>>> baseData) {
         try {
@@ -66,7 +63,7 @@ public class StructureSave {
                     String[] info = line.split(";");
                     if (info.length != 3) continue;
                     String structureName = info[0];
-                    for (RegionStructure<?,?> idk : structureTypes) {
+                    for (RegionStructure<?,?> idk : Features.STRUCTURE_TYPES) {
                         if (structureName.equals(idk.getName())) {
                             result.add(idk.at(Integer.parseInt(info[1]), Integer.parseInt(info[2])));
                             break;


### PR DESCRIPTION
this pull request tries to fix the error that caused clientcommands to mark seedcrackerx as incompatible

the crash was caused by [calling `List#of` in `StructureSave`](https://github.com/19MisterX98/SeedcrackerX/blob/472125f007a7623d454888f088ff87f296e03b73/src/main/java/kaptainwutax/seedcrackerX/config/StructureSave.java#L29) where one of the structure features defined in [`Features`](https://github.com/19MisterX98/SeedcrackerX/blob/472125f007a7623d454888f088ff87f296e03b73/src/main/java/kaptainwutax/seedcrackerX/Features.java#L32) was `null`

i'm still not sure what caused that to happen, but i have 2 hypotheses:
1. `StructureSave#loadStructures` was executed from `ClientPlayNetworkHandlerMixin#onGameJoin` before `Features#init` was ran
2. `Features#init` threw & consumed exceptions, which caused some fields to stay null

for the 1st hypothesis, in order to prevent `List#of` from throwing a `NullPointerException` when ran before the features are initialized, it instead uses a constant list that is dynamically filled as features are initialized. if a feature threw an exception while initializing, it will not be added to this list. i also made this list reset when `Config#setVersion` is ran, which was not done before and resulted in two copies of the features being loaded in memory at the same time.

for the second one, whenever a feature throws an exception while initializing, the exception will be output to the logs, and its respective block finder type will be disabled automatically to prevent crashing and burning