### PR TITLE
Fix Jitpack Zulu OpenJDK version

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,7 +1,7 @@
-# Tell Jitpack to build using Java 17 (defaults to 8)
+# Tell Jitpack to build using Java 21 (defaults to 8)
 before_install:
   # Fix: https://github.com/jitpack/jitpack.io/issues/4506#issuecomment-864562270
   - source "$HOME/.sdkman/bin/sdkman-init.sh"
   - sdk update
-  - sdk install java 21.34.19-zulu
-  - sdk use java 21.34.19-zulu
+  - sdk install java 21.0.3-zulu
+  - sdk use java 21.0.3-zulu


### PR DESCRIPTION
`21.34.19-zulu` is an invalid version.

![sdk list java](https://github.com/19MisterX98/SeedcrackerX/assets/79430821/6cb5755a-bc67-4a7e-bd9d-be94f96e9df6)
