### PR TITLE
Add hashed seed column to the database

### DIFF
--- a/src/main/java/kaptainwutax/seedcrackerX/util/Database.java
+++ b/src/main/java/kaptainwutax/seedcrackerX/util/Database.java
@@ -54,7 +54,7 @@ public class Database {
             data.put("version", Config.get().getVersion().name);
             data.put("username", client.player.getName().getString());
             data.put("hash", Config.get().anonymusSubmits ? 1 : 0);
-            data.put("hashedSeed", Long.toString(Hashing.sha256().hashLong(seed).asLong()));
+            data.put("hashedSeed", Hashing.sha256().hashLong(seed).asLong() + "L");
 
             HttpRequest request = HttpRequest.newBuilder()
                 .POST(HttpRequest.BodyPublishers.ofString(HttpAuthenticationService.buildQuery(data)))


### PR DESCRIPTION
This PR adds the hashed seed (as sent by the server) as column to the database. Currently the `serverIp` field serves the purpose of identifying the server. This can fail for two reasons:

1. Trivially if the server is not listed on the database the seed cannot be retrieved.
2. Depending on the OS, the host name part of the `serverIp` field can be different (iirc).

The hashed seed can possibly help in both cases. Firstly, while the server may not be listed in the database, it could be that a hash does match, because there is a possibility of servers having the same seed. Secondly the hash is OS independent.

This PR adds this field for future submissions to the database, but it leaves existing entries unchanged. The following JavaScript function can be used to augment the existing entries with the hashed seed:

```js
/**
 * @param {bigint} seed
 * @returns {Promise<bigint>}
 */
async function hashLongAsLong(seed) {
    const bytes = []
    for (let i = 0; i < 8; i++) {
        bytes.push(Number(seed & 0xFFn));
        seed >>= 8n;
    }

    const hash = new Uint8Array(await crypto.subtle.digest("SHA-256", new Int8Array(bytes)));

    let result = 0n;
    for (let i = 0; i < 8; i++) {
        result |= BigInt(hash[i]) << BigInt(8 * i);
    }
    if ((result & (1n << 63n)) === 0n) {
        return result;
    }
    return -((result ^ ((1n << 64n) - 1n)) + 1n);
}
```

This replicates Minecraft's behaviour of sending `Hashing.sha256().hashLong(seed).asLong()` to the client.