### PR TITLE
Add automatic database seed fetching based on connection string and hashed seed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ repositories {
 	maven { url "https://maven.seedfinding.com/" }
 	maven { url "https://maven-snapshots.seedfinding.com/" }
 	maven { url "https://jitpack.io" }
+	maven { url "https://pkgs.dev.azure.com/djtheredstoner/DevAuth/_packaging/public/maven/v1" }
 }
 
 configurations {
@@ -52,6 +53,10 @@ dependencies {
 	includedLibrary('com.seedfinding:mc_reversal:ca64c0890c106f1a2207623c316fce86f250b918') { transitive = false }
 
 	includedLibrary('com.seedfinding:latticg:1.06')
+
+	modRuntimeOnly('me.djtheredstoner:DevAuth-fabric:1.1.0') {
+		exclude group: 'net.fabricmc', module: 'fabric-loader'
+	}
 }
 
 processResources {

--- a/src/main/java/kaptainwutax/seedcrackerX/SeedCracker.java
+++ b/src/main/java/kaptainwutax/seedcrackerX/SeedCracker.java
@@ -6,6 +6,7 @@ import kaptainwutax.seedcrackerX.config.Config;
 import kaptainwutax.seedcrackerX.cracker.storage.DataStorage;
 import kaptainwutax.seedcrackerX.finder.FinderQueue;
 import kaptainwutax.seedcrackerX.init.ClientCommands;
+import kaptainwutax.seedcrackerX.util.Database;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
 import net.fabricmc.loader.api.FabricLoader;
@@ -32,6 +33,8 @@ public class SeedCracker implements ModInitializer {
                 entrypoints.add(entrypoint.getEntrypoint()));
 
         ClientCommandRegistrationCallback.EVENT.register((dispatcher, registryAccess) -> ClientCommands.registerCommands(dispatcher));
+
+        Database.fetchSeeds();
     }
 
     public DataStorage getDataStorage() {

--- a/src/main/java/kaptainwutax/seedcrackerX/util/Database.java
+++ b/src/main/java/kaptainwutax/seedcrackerX/util/Database.java
@@ -8,16 +8,31 @@ import com.mojang.authlib.exceptions.InvalidCredentialsException;
 import kaptainwutax.seedcrackerX.config.Config;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.text.Text;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpStatus;
+import org.apache.http.entity.ContentType;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
 public class Database {
+
+    private static final String DATABASE_POST_URL = "https://script.google.com/macros/s/AKfycbye87L-fEYq2EkgczvhKb_kGecp5wL1oX95vg45TRSwNvpv7K-53zoInGTeI1FZ0kv7DA/exec";
+    private static final String DATABASE_URL = "https://docs.google.com/spreadsheets/d/1tuQiE-0leW88em9OHbZnH-RFNhVqgoHhIt9WQbeqqWw/export?format=csv&gid=0"; // script link is not updated, this works fine
+    private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build();
+    private static final Duration TIMEOUT = Duration.ofSeconds(10);
+    private static final String SEEDCRACKERX_USER_AGENT = "SeedcrackerX mod";
+
+    private static final Map<String, Long> connectionToSeed = new HashMap<>();
+    private static final Map<Long, Long> hashedSeedToSeed = new HashMap<>();
 
     public static Text joinFakeServerForAuth() {
         try {
@@ -39,10 +54,15 @@ public class Database {
         return null;
     }
 
+    public static @Nullable Long getSeed(String connection, long hashedSeed) {
+        Long seed = connectionToSeed.get(connection);
+        if (seed != null) {
+            return seed;
+        }
+        return hashedSeedToSeed.get(hashedSeed);
+    }
+
     public static void handleDatabaseCall(Long seed) {
-        HttpClient httpClient = HttpClient.newBuilder()
-                .version(HttpClient.Version.HTTP_2)
-                .build();
         MinecraftClient client = MinecraftClient.getInstance();
         Map<String,Object> data = new HashMap<>();
         data.put("serverIp", client.getNetworkHandler().getConnection().getAddress().toString());
@@ -52,17 +72,16 @@ public class Database {
         data.put("username", client.player.getName().getString());
         data.put("hash", Config.get().anonymusSubmits? 1 : 0);
 
-
-        HttpRequest request = HttpRequest.newBuilder()
-                .POST(HttpRequest.BodyPublishers.ofString(HttpAuthenticationService.buildQuery(data)))
-                .uri(URI.create("https://script.google.com/macros/s/AKfycbye87L-fEYq2EkgczvhKb_kGecp5wL1oX95vg45TRSwNvpv7K-53zoInGTeI1FZ0kv7DA/exec"))
-                .setHeader("User-Agent", "SeedcrackerX mod")
-                .header("Content-Type", "application/x-www-form-urlencoded")
-                .build();
+        HttpRequest request = HttpRequest.newBuilder(URI.create(DATABASE_POST_URL))
+            .timeout(TIMEOUT)
+            .POST(HttpRequest.BodyPublishers.ofString(HttpAuthenticationService.buildQuery(data)))
+            .setHeader(HttpHeaders.USER_AGENT, SEEDCRACKERX_USER_AGENT)
+            .header(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_FORM_URLENCODED.getMimeType())
+            .build();
 
         try {
-            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-            if (response.statusCode() == 302) { //the page says "document moved" but the post gets processed
+            HttpResponse<String> response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() == HttpStatus.SC_MOVED_TEMPORARILY) { //the page says "document moved" but the post gets processed
                 Log.warn("database.success");
             } else {
                 Log.warn("database.fail");
@@ -70,5 +89,31 @@ public class Database {
         } catch (IOException | InterruptedException e) {
             Log.warn("database.fail");
         }
+    }
+
+    public static void fetchSeeds() {
+        HttpRequest request = HttpRequest.newBuilder(URI.create(DATABASE_URL))
+            .timeout(TIMEOUT)
+            .GET()
+            .setHeader(HttpHeaders.USER_AGENT, SEEDCRACKERX_USER_AGENT)
+            .build();
+        HTTP_CLIENT.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+            .thenApply(HttpResponse::body)
+            .thenAccept(Database::parseCsv);
+    }
+
+    private static void parseCsv(String csv) {
+        Arrays.stream(csv.split("\n")).skip(1).forEach(row -> {
+            try {
+                String[] seedEntry = row.split(",");
+                String connection = seedEntry[0];
+                String seedString = seedEntry[2];
+                long seed = Long.parseLong(seedString.substring(0, seedString.length() - 1));
+                connectionToSeed.put(connection, seed);
+                long hashedSeed = Long.parseLong(seedEntry[6]);
+                hashedSeedToSeed.put(hashedSeed, seed);
+            } catch (NumberFormatException | ArrayIndexOutOfBoundsException ignored) {
+            }
+        });
     }
 }

--- a/src/main/resources/assets/seedcrackerx/lang/en_us.json
+++ b/src/main/resources/assets/seedcrackerx/lang/en_us.json
@@ -65,6 +65,7 @@
   "tmachine.decoratorWorldSeedSearch": "Looking for world seeds with decorators...",
   "tmachine.hashedSeedWorldSeedSearch": "Looking for world seeds with hashed seed...",
   "tmachine.foundWorldSeed": "Found world seed ${SEED}.",
+  "tmachine.foundWorldSeedFromDatabase": "Found world seed ${SEED} from database.",
   "tmachine.worldSeedSearchFinished": "Finished searching for world seeds.",
   "tmachine.noResultsRevertingToBiomes": "Finished search with no results, reverting back to biomes.",
   "tmachine.moreBiomesNeeded": "You need to collect more biome information",


### PR DESCRIPTION
As it is currently implemented, if there is a database match, the seed will be sent to the player every time they log in or respawn. If this is too annoying, it can be changed to only do so on log ins. However this may have the issue that when the nether has a different seed, it won't be communicated to the player.

Some notes:

- I added [DevAuth](https://github.com/DJtheRedstoner/DevAuth) to be able to easily test on multiplayer servers. A server that currently works as a nice example of this feature is `java.donutsmp.net`.
- The version is currently ignored when fetching the database, this can be changed if necessary.
- The database URL for fetching the seeds is currently CSV-based, so far it has worked fine but perhaps it can be replaced with a script if necessary.