### PR TITLE
Add fabric-api as a dependency

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -33,7 +33,8 @@
     "fabric-command-api-v2": "*",
     "fabric-rendering-v1": "*",
     "fabric-resource-loader-v0": "*",
-    "cloth-config": "*"
+    "cloth-config": "*",
+    "fabric-api": ">=0.119.6",
   },
   "suggests": {
     "flamingo": "*",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -34,7 +34,7 @@
     "fabric-rendering-v1": "*",
     "fabric-resource-loader-v0": "*",
     "cloth-config": "*",
-    "fabric-api": ">=0.119.6",
+    "fabric-api": ">=0.119.6"
   },
   "suggests": {
     "flamingo": "*",


### PR DESCRIPTION
SeedcrackerX crashes without fabric api when trying to connect to a server/join a single world.