### PR TITLE
Fix: Correct mixin signature for ClientWorld#disconnect

### DIFF
--- a/src/main/java/kaptainwutax/seedcrackerX/mixin/ClientWorldMixin.java
+++ b/src/main/java/kaptainwutax/seedcrackerX/mixin/ClientWorldMixin.java
@@ -26,7 +26,7 @@ public abstract class ClientWorldMixin extends World {
     }
 
     @Inject(method = "disconnect", at = @At("HEAD"))
-    private void disconnect(CallbackInfo ci) {
+    private void disconnect(Text reasonText, CallbackInfo ci) {
         StructureSave.saveStructures(SeedCracker.get().getDataStorage().baseSeedData);
         SeedCracker.get().reset();
     }


### PR DESCRIPTION
The previous method signature was missing the `Text reasonText` parameter, causing the mixin injection to fail. This change adds the correct parameter, ensuring the save/reset logic is executed on disconnect.