### PR TITLE
fix: critical crash in 1.21.11 caused by outdated cloth config version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ archives_base_name=seedcrackerX
 # Dependencies
 fabric_api_version=0.139.4+1.21.11
 modmenu_version=16.0.0-rc.1
-cloth_config_version=20.0.149
+cloth_config_version=21.11.151
 
 seedfinding_math_version=851e9d0577dfdca50154e98f1d334bd31c641326
 seedfinding_seed_version=55f6242001f7eb4226df4ed0d023f1838a54a99d


### PR DESCRIPTION
simple but important fix that solves a crash when trying to use seedcracker in 1.21.11 because the mod was using an old version of cloth config api  #429 