### PR TITLE
Data Export

### DIFF
--- a/src/main/java/kaptainwutax/seedcrackerX/command/DataCommand.java
+++ b/src/main/java/kaptainwutax/seedcrackerX/command/DataCommand.java
@@ -1,14 +1,27 @@
 package kaptainwutax.seedcrackerX.command;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+import java.io.FileWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.seedfinding.mcfeature.structure.RegionStructure;
 import kaptainwutax.seedcrackerX.SeedCracker;
 import kaptainwutax.seedcrackerX.config.StructureSave;
+import kaptainwutax.seedcrackerX.cracker.BiomeData;
 import kaptainwutax.seedcrackerX.cracker.DataAddedEvent;
 import kaptainwutax.seedcrackerX.cracker.storage.DataStorage;
 import kaptainwutax.seedcrackerX.util.Log;
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.ChatFormatting;
 import net.minecraft.locale.Language;
 
@@ -33,6 +46,10 @@ public class DataCommand extends ClientCommand {
 
         builder.then(literal("restore")
                 .executes(this::restoreData)
+        );
+
+        builder.then(literal("export")
+                .executes(this::exportData)
         );
     }
 
@@ -62,6 +79,63 @@ public class DataCommand extends ClientCommand {
         } else {
             Log.warn("data.restoreFailed");
         }
+        return 0;
+    }
+
+    private int exportData(CommandContext<FabricClientCommandSource> context) {
+        DataStorage storage = SeedCracker.get().getDataStorage();
+        JsonObject root = new JsonObject();
+
+        JsonArray baseArray = new JsonArray();
+        for (DataStorage.Entry<com.seedfinding.mcfeature.Feature.Data<?>> entry : storage.baseSeedData) {
+            JsonObject obj = new JsonObject();
+            obj.addProperty("name", entry.data.feature.getName());
+            obj.addProperty("chunkX", entry.data.chunkX);
+            obj.addProperty("chunkZ", entry.data.chunkZ);
+            baseArray.add(obj);
+        }
+        root.add("baseData", baseArray);
+
+        JsonArray biomeArray = new JsonArray();
+        for (DataStorage.Entry<BiomeData> entry : storage.getBiomeSeedData()) {
+            JsonObject obj = new JsonObject();
+            obj.addProperty("name", entry.data.biome.getName());
+            obj.addProperty("x", entry.data.x);
+            obj.addProperty("z", entry.data.z);
+            biomeArray.add(obj);
+        }
+        root.add("biomeData", biomeArray);
+
+        if (storage.getPillarData() != null) {
+            JsonArray heightsArray = new JsonArray();
+            for (Integer height : storage.getPillarData().getHeights()) {
+                heightsArray.add(height);
+            }
+            root.add("pillarData", heightsArray);
+        }
+
+        if (storage.hashedSeedData != null) {
+            root.addProperty("hashedSeed", storage.hashedSeedData.getHashedSeed());
+        }
+
+        try {
+            Path configDir = FabricLoader.getInstance().getConfigDir().resolve("SeedCrackerX exported data");
+            Files.createDirectories(configDir);
+
+            String filename = "export_" + new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss").format(new Date()) + ".json";
+            Path exportPath = configDir.resolve(filename);
+
+            Gson gson = new GsonBuilder().setPrettyPrinting().create();
+            try (FileWriter writer = new FileWriter(exportPath.toFile())) {
+                gson.toJson(root, writer);
+            }
+
+            sendFeedback("Successfully exported data to " + filename, ChatFormatting.GREEN);
+        } catch (Exception e) {
+            SeedCracker.LOGGER.error("Failed to export SeedCrackerX data", e);
+            sendFeedback("Failed to export data. Check the logs.", ChatFormatting.RED);
+        }
+
         return 0;
     }
 

--- a/src/main/java/kaptainwutax/seedcrackerX/cracker/PillarData.java
+++ b/src/main/java/kaptainwutax/seedcrackerX/cracker/PillarData.java
@@ -36,4 +36,8 @@ public class PillarData {
         return heights;
     }
 
+    public List<Integer> getHeights() {
+        return this.heights;
+    }
+
 }

--- a/src/main/java/kaptainwutax/seedcrackerX/cracker/storage/DataStorage.java
+++ b/src/main/java/kaptainwutax/seedcrackerX/cracker/storage/DataStorage.java
@@ -247,4 +247,12 @@ public class DataStorage {
         }
     }
 
+    public ScheduledSet<Entry<BiomeData>> getBiomeSeedData() {
+        return this.biomeSeedData;
+    }
+
+    public PillarData getPillarData() {
+        return this.pillarData;
+    }
+
 }

--- a/src/main/java/kaptainwutax/seedcrackerX/structures/TrialChambers.java
+++ b/src/main/java/kaptainwutax/seedcrackerX/structures/TrialChambers.java
@@ -25,6 +25,11 @@ public class TrialChambers extends UniformStructure<TrialChambers> {
     }
 
     @Override
+    public String getName() {
+        return "trial_chambers";
+    }
+
+    @Override
     public Dimension getValidDimension() {
         return Dimension.OVERWORLD;
     }


### PR DESCRIPTION
Adds a new command: `/seedcracker data export`. This exports collected base data (structures/decorators), biome data, pillar heights, and hashed seed into a JSON file. The JSON is saved with a timestamped filename to `config/SeedCrackerX exported data/`.
Added public getter methods `getBiomeSeedData()`, `getPillarData()`, and `getHeights()` to access protected tracking sets from the command class.
Example JSON data: 
```json
{
  "baseData": [
    {
      "name": "trial_chambers",
      "chunkX": 71,
      "chunkZ": 69
    },
    {
      "name": "trial_chambers",
      "chunkX": 82,
      "chunkZ": 114
    },
    {
      "name": "dungeon",
      "chunkX": 64,
      "chunkZ": 64
    },
    {
      "name": "dungeon",
      "chunkX": 87,
      "chunkZ": 64
    }
  ],
  "biomeData": [
    {
      "name": "badlands",
      "x": 232,
      "z": 303
    },
    {
      "name": "savanna_plateau",
      "x": 228,
      "z": 292
    },
    {
      "name": "warm_ocean",
      "x": 404,
      "z": 467
    }
  ],
  "pillarData": [
    100,
    91,
    97,
    79,
    88,
    76,
    85,
    82,
    94,
    103
  ],
  "hashedSeed": -8107327391882072000
}
```

Please let me know if there anything I should change!