### PR TITLE
BURIED TREASURE FIX FOR 1.21.9 - 1.21.11

### DIFF
--- a/src/main/java/kaptainwutax/seedcrackerX/finder/structure/BuriedTreasureFinder.java
+++ b/src/main/java/kaptainwutax/seedcrackerX/finder/structure/BuriedTreasureFinder.java
@@ -73,7 +73,7 @@ public class BuriedTreasureFinder extends BlockFinder {
 
         result.removeIf(pos -> {
             BlockState chest = world.getBlockState(pos);
-            if (chest.hasProperty(ChestBlock.WATERLOGGED)) return true;
+            if (chest.getValue(ChestBlock.WATERLOGGED)) return true;
 
             BlockState chestHolder = world.getBlockState(pos.below());
             return !CHEST_HOLDERS.contains(chestHolder);


### PR DESCRIPTION
Theres literally NO WAY this was the ENTIRE reason buried treasure couldn't be used bro😭

BuriedTreasureFinder.findInChunk() checks chest.hasProperty(ChestBlock.WATERLOGGED), which just checks that the WATERLOGGED property exists on the blockstate — which it always does for ChestBlock, regardless of value. So the condition is always true and every single detected treasure chest gets filtered out of the result before it's ever added to the data storage. Should be getValue(WATERLOGGED) to actually read the boolean and only discard chests that are genuinely waterlogged.

One-line fix, verified against current master. Confirmed in-game that detection works after the change (test seed available if wanted).